### PR TITLE
modernize: use `any` instead of `interface{}`

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,11 +10,11 @@ import (
 )
 
 type clientRequest struct {
-	Method     string      `json:"method"`
-	Parameters interface{} `json:"parameters"`
-	Oneway     bool        `json:"oneway,omitempty"`
-	More       bool        `json:"more,omitempty"`
-	Upgrade    bool        `json:"upgrade,omitempty"`
+	Method     string `json:"method"`
+	Parameters any    `json:"parameters"`
+	Oneway     bool   `json:"oneway,omitempty"`
+	More       bool   `json:"more,omitempty"`
+	Upgrade    bool   `json:"upgrade,omitempty"`
 }
 
 type clientReply struct {
@@ -125,7 +125,7 @@ func (c *Client) readLoop() {
 //
 // in is a Go value marshaled to a JSON object which contains the request
 // parameters. Similarly, out will be populated with the reply parameters.
-func (c *Client) Do(method string, in, out interface{}) error {
+func (c *Client) Do(method string, in, out any) error {
 	req := clientRequest{
 		Method:     method,
 		Parameters: in,
@@ -144,7 +144,7 @@ func (c *Client) Do(method string, in, out interface{}) error {
 
 // DoMore is similar to Do, but indicates to the service that multiple replies
 // are expected.
-func (c *Client) DoMore(method string, in interface{}) (*ClientCall, error) {
+func (c *Client) DoMore(method string, in any) (*ClientCall, error) {
 	req := clientRequest{
 		Method:     method,
 		Parameters: in,
@@ -178,7 +178,7 @@ type ClientCall struct {
 // Next waits for a reply.
 //
 // If there are no more replies, io.EOF is returned.
-func (cc *ClientCall) Next(out interface{}) error {
+func (cc *ClientCall) Next(out any) error {
 	if cc.ch == nil {
 		return io.EOF
 	}
@@ -190,7 +190,7 @@ func (cc *ClientCall) Next(out interface{}) error {
 	return err
 }
 
-func (cc *ClientCall) next(out interface{}) (continues bool, err error) {
+func (cc *ClientCall) next(out any) (continues bool, err error) {
 	if out == nil {
 		out = new(struct{})
 	}

--- a/server.go
+++ b/server.go
@@ -19,15 +19,15 @@ type ServerRequest struct {
 }
 
 type serverReply struct {
-	Parameters interface{} `json:"parameters"`
-	Continues  bool        `json:"continues,omitempty"`
-	Error      string      `json:"error,omitempty"`
+	Parameters any    `json:"parameters"`
+	Continues  bool   `json:"continues,omitempty"`
+	Error      string `json:"error,omitempty"`
 }
 
 // ServerError is an error to be sent to a Varlink client.
 type ServerError struct {
 	Name       string
-	Parameters interface{}
+	Parameters any
 }
 
 // Error implements the error interface.
@@ -65,7 +65,7 @@ func (call *ServerCall) reply(reply *serverReply) error {
 // Reply sends a non-final reply.
 //
 // This can only be used if ServerRequest.More is set to true.
-func (call *ServerCall) Reply(parameters interface{}) error {
+func (call *ServerCall) Reply(parameters any) error {
 	return call.reply(&serverReply{
 		Parameters: parameters,
 		Continues:  true,
@@ -75,7 +75,7 @@ func (call *ServerCall) Reply(parameters interface{}) error {
 // CloseWithReply sends a final reply and closes the call.
 //
 // No more replies may be sent.
-func (call *ServerCall) CloseWithReply(parameters interface{}) error {
+func (call *ServerCall) CloseWithReply(parameters any) error {
 	return call.reply(&serverReply{Parameters: parameters})
 }
 

--- a/varlink.go
+++ b/varlink.go
@@ -22,7 +22,7 @@ func newConn(c net.Conn) *conn {
 	}
 }
 
-func (c *conn) writeMessage(v interface{}) error {
+func (c *conn) writeMessage(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func (c *conn) writeMessage(v interface{}) error {
 	return err
 }
 
-func (c *conn) readMessage(v interface{}) error {
+func (c *conn) readMessage(v any) error {
 	b, err := c.br.ReadBytes(0)
 	if err != nil {
 		return err


### PR DESCRIPTION
Modernize code to use `any` instead of `interface{}`.

The process is automated with gopls's modernizer:
```console
$ go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./... 2>&1 | sed -e "s@${PWD}/@@"
client.go:14:13: interface{} can be replaced by any
client.go:128:44: interface{} can be replaced by any
client.go:147:43: interface{} can be replaced by any
client.go:181:32: interface{} can be replaced by any
client.go:193:32: interface{} can be replaced by any
server.go:22:13: interface{} can be replaced by any
server.go:30:13: interface{} can be replaced by any
server.go:68:42: interface{} can be replaced by any
server.go:78:51: interface{} can be replaced by any
varlink.go:25:31: interface{} can be replaced by any
varlink.go:35:30: interface{} can be replaced by any
exit status 3
```

The fixes are then applied with `-fix`.