### PR TITLE
Handle client requests without 'parameters'

### DIFF
--- a/example/internal/varlink/stringapi/org.example.string.varlink
+++ b/example/internal/varlink/stringapi/org.example.string.varlink
@@ -7,3 +7,5 @@ method Repeat(
 method Reverse(
     input: string
 ) -> (output: string)
+
+method Random() -> (output: string)

--- a/example/main.go
+++ b/example/main.go
@@ -37,6 +37,11 @@ func (stringBackend) Reverse(in *stringapi.ReverseIn) (*stringapi.ReverseOut, er
 	return &stringapi.ReverseOut{Output: string(result)}, nil
 }
 
+func (stringBackend) Random(_ *stringapi.RandomIn) (*stringapi.RandomOut, error) {
+	// chosen by a fair dice roll, guaranteed to be random.
+	return &stringapi.RandomOut{Output: "4"}, nil
+}
+
 func main() {
 	registry := varlink.NewRegistry(&varlink.RegistryOptions{
 		Vendor:  "emersion/go-varlink",

--- a/server.go
+++ b/server.go
@@ -18,6 +18,22 @@ type ServerRequest struct {
 	Upgrade    bool            `json:"upgrade,omitempty"`
 }
 
+// UnmarshalJSON sanitizes a client input.
+func (req *ServerRequest) UnmarshalJSON(data []byte) error {
+	// a temporary type alias helps us unmarshall the struct
+	// without recursing into this method by accident
+	type rawServerRequest ServerRequest
+	if err := json.Unmarshal(data, (*rawServerRequest)(req)); err != nil {
+		return err
+	}
+
+	// 'parameters' field may be missing (issue #20)
+	if len(req.Parameters) == 0 {
+		req.Parameters = json.RawMessage("{}")
+	}
+	return nil
+}
+
 type serverReply struct {
 	Parameters interface{} `json:"parameters"`
 	Continues  bool        `json:"continues,omitempty"`


### PR DESCRIPTION
Some Varlink implementations, namely the official Python one, do not include 'parameters' key in their request, if the called method takes no arguments. Previously, the server would refuse to serve such a request, returning JSON deserialization error.

Custom UnmarshalJSON method sanitizes client input and sets the 'raw.Parameters' field before the ServerRequest is forwarded to the generated code.

The second commit in this PR is code I found useful when developing and verifying this patch.

Closes: https://github.com/emersion/go-varlink/issues/20

Assisted-By: Claude Code

---

The consultation in #20 already gave me a direction, and I took this specific approach because it manages the fix on a single place, and autogenerated code living in other repositories isn't affected and gets it for free.