### PR TITLE
Add support for connection upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ interface which needs to be implemented:
 ```go
 type backend struct{}
 
-func (backend) Jump(in *JumpIn) (*JumpOut, error) {
+func (backend) Jump(call *JumpCall, in *JumpIn) (*JumpOut, error) {
     log.Print(in.Latitude, in.Longitude)
     return nil, nil
 }

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package varlink
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -40,20 +41,32 @@ func (err *ClientError) Error() string {
 type Client struct {
 	conn *conn
 
-	mutex   sync.Mutex
-	pending []chan<- clientReply
-	err     error
+	mutex     sync.Mutex
+	pending   []chan<- clientReply
+	upgradeCh chan<- clientReply
+	err       error
+
+	readDone chan struct{}
 }
 
 // NewClient creates a Varlink client from a net.Conn.
 func NewClient(conn net.Conn) *Client {
-	c := &Client{conn: newConn(conn)}
+	c := &Client{
+		conn:     newConn(conn),
+		readDone: make(chan struct{}),
+	}
 	go c.readLoop()
 	return c
 }
 
 // Close closes the connection.
+//
+// Once the connection has been hijacked it belongs to the caller of DoUpgrade,
+// which must close it: this becomes a no-op.
 func (c *Client) Close() error {
+	if c.conn.hijacked.Load() {
+		return nil
+	}
 	return c.conn.Close()
 }
 
@@ -67,8 +80,15 @@ func (c *Client) writeRequest(req *clientRequest, ch chan<- clientReply) error {
 		return c.err
 	}
 
+	if c.upgradeCh != nil {
+		return fmt.Errorf("varlink: an upgrade call is already in flight")
+	}
+
 	if !req.Oneway {
 		c.pending = append(c.pending, ch)
+		if req.Upgrade {
+			c.upgradeCh = ch
+		}
 	}
 
 	if req.Parameters == nil {
@@ -87,6 +107,7 @@ func (c *Client) writeRequest(req *clientRequest, ch chan<- clientReply) error {
 
 func (c *Client) readLoop() {
 	var err error
+	var hijack bool
 	defer func() {
 		c.mutex.Lock()
 		defer c.mutex.Unlock()
@@ -99,6 +120,7 @@ func (c *Client) readLoop() {
 			close(ch)
 		}
 		c.pending = nil
+		close(c.readDone)
 	}()
 
 	for {
@@ -116,6 +138,13 @@ func (c *Client) readLoop() {
 			ch = c.pending[0]
 			if !reply.Continues {
 				c.pending = c.pending[1:]
+				if ch == c.upgradeCh {
+					if reply.Error == "" {
+						hijack = true
+					} else {
+						c.upgradeCh = nil
+					}
+				}
 			}
 		}
 		c.mutex.Unlock()
@@ -126,6 +155,11 @@ func (c *Client) readLoop() {
 		}
 
 		ch <- reply
+
+		if hijack {
+			err = ErrHijacked
+			break
+		}
 	}
 }
 
@@ -169,6 +203,42 @@ func (c *Client) DoOneway(method string, in interface{}) error {
 		Oneway:     true,
 	}
 	return c.writeRequest(&req, nil)
+}
+
+// DoUpgrade is similar to Do, but requests the connection to be upgraded.
+//
+// If the service accepts the upgrade, the connection is taken over, giving up
+// Varlink message framing: the caller must read from the returned bufio.Reader,
+// and is responsible for closing the connection. Subsequent calls fail with
+// ErrHijacked.
+//
+// The returned connection and reader are nil if the service replied with an
+// error, in which case the Client remains usable.
+func (c *Client) DoUpgrade(method string, in, out interface{}) (net.Conn, *bufio.Reader, error) {
+	req := clientRequest{
+		Method:     method,
+		Parameters: in,
+		Upgrade:    true,
+	}
+	cc, err := c.do(&req)
+	if err != nil {
+		return nil, nil, err
+	}
+	continues, err := cc.next(out)
+	if continues {
+		c.conn.Close()
+		return nil, nil, fmt.Errorf("varlink: received continues=true in response to a more=false request")
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// the reply was successful: readLoop has stopped reading
+	<-c.readDone
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.conn.hijack()
 }
 
 func (c *Client) do(req *clientRequest) (*ClientCall, error) {

--- a/cmd/varlinkgen/main.go
+++ b/cmd/varlinkgen/main.go
@@ -209,6 +209,39 @@ func main() {
 				jen.Id("unmarshalError").Call(jen.Id("err")),
 			),
 		)
+
+		f.Comment("// " + name + "Upgrade calls " + iface.Name + "." + name + ", requesting the")
+		f.Comment("// connection to be upgraded.")
+		f.Comment("//")
+		f.Comment("// The service must take over the connection: if it replies without doing so,")
+		f.Comment("// the connection is closed. On success the caller owns the connection and must")
+		f.Comment("// close it, and must read from the returned bufio.Reader.")
+		f.Func().Params(
+			jen.Id("c").Id("Client"),
+		).Id(name+"Upgrade").Params(
+			jen.Id("in").Op("*").Id(name+"In"),
+		).Params(
+			jen.Op("*").Id(name+"Out"),
+			jen.Qual("net", "Conn"),
+			jen.Op("*").Qual("bufio", "Reader"),
+			jen.Id("error"),
+		).Block(
+			jen.If(jen.Id("in").Op("==").Nil()).Block(
+				jen.Id("in").Op("=").New(jen.Id(name+"In")),
+			),
+			jen.Id("out").Op(":=").New(jen.Id(name+"Out")),
+			jen.List(jen.Id("conn"), jen.Id("br"), jen.Id("err")).Op(":=").Id("c").Dot("Client").Dot("DoUpgrade").Call(
+				jen.Lit(iface.Name+"."+name),
+				jen.Id("in"),
+				jen.Id("out"),
+			),
+			jen.Return().List(
+				jen.Id("out"),
+				jen.Id("conn"),
+				jen.Id("br"),
+				jen.Id("unmarshalError").Call(jen.Id("err")),
+			),
+		)
 	}
 
 	f.Line()

--- a/cmd/varlinkgen/main.go
+++ b/cmd/varlinkgen/main.go
@@ -112,6 +112,34 @@ func main() {
 
 		f.Type().Id(name + "In").Add(genStruct(method.In))
 		f.Type().Id(name + "Out").Add(genStruct(method.Out))
+
+		f.Comment("// " + name + "Call is an in-progress " + iface.Name + "." + name + " call.")
+		f.Comment("//")
+		f.Comment("// A reply may be sent with Reply or CloseWithReply instead of returning it")
+		f.Comment("// from the Backend method, for instance to hijack the connection afterwards.")
+		f.Type().Id(name+"Call").Struct(
+			jen.Op("*").Qual("github.com/emersion/go-varlink", "ServerCall"),
+			jen.Id("Request").Op("*").Qual("github.com/emersion/go-varlink", "ServerRequest"),
+		)
+
+		f.Comment("// Reply sends a non-final reply.")
+		f.Func().Params(
+			jen.Id("call").Op("*").Id(name + "Call"),
+		).Id("Reply").Params(
+			jen.Id("out").Op("*").Id(name + "Out"),
+		).Id("error").Block(
+			jen.Return().Id("call").Dot("ServerCall").Dot("Reply").Call(jen.Id("out")),
+		)
+
+		f.Comment("// CloseWithReply sends a final reply and closes the call.")
+		f.Func().Params(
+			jen.Id("call").Op("*").Id(name + "Call"),
+		).Id("CloseWithReply").Params(
+			jen.Id("out").Op("*").Id(name + "Out"),
+		).Id("error").Block(
+			jen.Return().Id("call").Dot("ServerCall").Dot("CloseWithReply").Call(jen.Id("out")),
+		)
+
 		f.Line()
 	}
 
@@ -188,6 +216,7 @@ func main() {
 	var backendMethods []jen.Code
 	for _, name := range methodNames {
 		backendMethods = append(backendMethods, jen.Id(name).Params(
+			jen.Op("*").Id(name+"Call"),
 			jen.Op("*").Id(name+"In"),
 		).Params(
 			jen.Op("*").Id(name+"Out"),
@@ -195,6 +224,12 @@ func main() {
 		))
 	}
 
+	f.Comment("// Backend implements the " + iface.Name + " Varlink interface.")
+	f.Comment("//")
+	f.Comment("// A method may send the final reply itself via the provided call rather than")
+	f.Comment("// returning it, for instance to hijack the connection. It must then return a nil")
+	f.Comment("// output: the output is ignored, and returning an error after replying drops the")
+	f.Comment("// connection.")
 	f.Type().Id("Backend").Interface(backendMethods...)
 
 	f.Line()
@@ -237,7 +272,13 @@ func main() {
 			).Block(
 				jen.Return().Id("err"),
 			),
-			jen.List(jen.Id("out"), jen.Id("err")).Op("=").Id("h").Dot("Backend").Dot(name).Call(jen.Id("in")),
+			jen.List(jen.Id("out"), jen.Id("err")).Op("=").Id("h").Dot("Backend").Dot(name).Call(
+				jen.Op("&").Id(name+"Call").Values(
+					jen.Id("ServerCall").Op(":").Id("call"),
+					jen.Id("Request").Op(":").Id("req"),
+				),
+				jen.Id("in"),
+			),
 		))
 	}
 	methodCases = append(methodCases, jen.Default().Block(
@@ -263,6 +304,9 @@ func main() {
 		jen.Switch(jen.Id("req").Dot("Method")).Block(methodCases...),
 		jen.If(jen.Id("err").Op("!=").Nil()).Block(
 			jen.Return().Id("marshalError").Call(jen.Id("err")),
+		),
+		jen.If(jen.Id("call").Dot("Replied").Call()).Block(
+			jen.Return().Nil(),
 		),
 		jen.Return().Id("call").Dot("CloseWithReply").Call(jen.Id("out")),
 	)

--- a/example/internal/varlink/calcapi/org.example.calc.go
+++ b/example/internal/varlink/calcapi/org.example.calc.go
@@ -3,8 +3,10 @@
 package calcapi
 
 import (
+	"bufio"
 	"encoding/json"
 	govarlink "github.com/emersion/go-varlink"
+	"net"
 )
 
 type DivisionByZeroError struct{}
@@ -96,6 +98,21 @@ func (c Client) Divide(in *DivideIn) (*DivideOut, error) {
 	err := c.Client.Do("org.example.calc.Divide", in, out)
 	return out, unmarshalError(err)
 }
+
+// DivideUpgrade calls org.example.calc.Divide, requesting the
+// connection to be upgraded.
+//
+// The service must take over the connection: if it replies without doing so,
+// the connection is closed. On success the caller owns the connection and must
+// close it, and must read from the returned bufio.Reader.
+func (c Client) DivideUpgrade(in *DivideIn) (*DivideOut, net.Conn, *bufio.Reader, error) {
+	if in == nil {
+		in = new(DivideIn)
+	}
+	out := new(DivideOut)
+	conn, br, err := c.Client.DoUpgrade("org.example.calc.Divide", in, out)
+	return out, conn, br, unmarshalError(err)
+}
 func (c Client) Multiply(in *MultiplyIn) (*MultiplyOut, error) {
 	if in == nil {
 		in = new(MultiplyIn)
@@ -103,6 +120,21 @@ func (c Client) Multiply(in *MultiplyIn) (*MultiplyOut, error) {
 	out := new(MultiplyOut)
 	err := c.Client.Do("org.example.calc.Multiply", in, out)
 	return out, unmarshalError(err)
+}
+
+// MultiplyUpgrade calls org.example.calc.Multiply, requesting the
+// connection to be upgraded.
+//
+// The service must take over the connection: if it replies without doing so,
+// the connection is closed. On success the caller owns the connection and must
+// close it, and must read from the returned bufio.Reader.
+func (c Client) MultiplyUpgrade(in *MultiplyIn) (*MultiplyOut, net.Conn, *bufio.Reader, error) {
+	if in == nil {
+		in = new(MultiplyIn)
+	}
+	out := new(MultiplyOut)
+	conn, br, err := c.Client.DoUpgrade("org.example.calc.Multiply", in, out)
+	return out, conn, br, unmarshalError(err)
 }
 
 // Backend implements the org.example.calc Varlink interface.

--- a/example/internal/varlink/calcapi/org.example.calc.go
+++ b/example/internal/varlink/calcapi/org.example.calc.go
@@ -21,12 +21,50 @@ type DivideOut struct {
 	Result int `json:"result"`
 }
 
+// DivideCall is an in-progress org.example.calc.Divide call.
+//
+// A reply may be sent with Reply or CloseWithReply instead of returning it
+// from the Backend method, for instance to hijack the connection afterwards.
+type DivideCall struct {
+	*govarlink.ServerCall
+	Request *govarlink.ServerRequest
+}
+
+// Reply sends a non-final reply.
+func (call *DivideCall) Reply(out *DivideOut) error {
+	return call.ServerCall.Reply(out)
+}
+
+// CloseWithReply sends a final reply and closes the call.
+func (call *DivideCall) CloseWithReply(out *DivideOut) error {
+	return call.ServerCall.CloseWithReply(out)
+}
+
 type MultiplyIn struct {
 	A int `json:"a"`
 	B int `json:"b"`
 }
 type MultiplyOut struct {
 	Result int `json:"result"`
+}
+
+// MultiplyCall is an in-progress org.example.calc.Multiply call.
+//
+// A reply may be sent with Reply or CloseWithReply instead of returning it
+// from the Backend method, for instance to hijack the connection afterwards.
+type MultiplyCall struct {
+	*govarlink.ServerCall
+	Request *govarlink.ServerRequest
+}
+
+// Reply sends a non-final reply.
+func (call *MultiplyCall) Reply(out *MultiplyOut) error {
+	return call.ServerCall.Reply(out)
+}
+
+// CloseWithReply sends a final reply and closes the call.
+func (call *MultiplyCall) CloseWithReply(out *MultiplyOut) error {
+	return call.ServerCall.CloseWithReply(out)
 }
 
 type Client struct {
@@ -67,9 +105,15 @@ func (c Client) Multiply(in *MultiplyIn) (*MultiplyOut, error) {
 	return out, unmarshalError(err)
 }
 
+// Backend implements the org.example.calc Varlink interface.
+//
+// A method may send the final reply itself via the provided call rather than
+// returning it, for instance to hijack the connection. It must then return a nil
+// output: the output is ignored, and returning an error after replying drops the
+// connection.
 type Backend interface {
-	Divide(*DivideIn) (*DivideOut, error)
-	Multiply(*MultiplyIn) (*MultiplyOut, error)
+	Divide(*DivideCall, *DivideIn) (*DivideOut, error)
+	Multiply(*MultiplyCall, *MultiplyIn) (*MultiplyOut, error)
 }
 
 type Handler struct {
@@ -100,13 +144,13 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
 			return err
 		}
-		out, err = h.Backend.Divide(in)
+		out, err = h.Backend.Divide(&DivideCall{ServerCall: call, Request: req}, in)
 	case "org.example.calc.Multiply":
 		in := new(MultiplyIn)
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
 			return err
 		}
-		out, err = h.Backend.Multiply(in)
+		out, err = h.Backend.Multiply(&MultiplyCall{ServerCall: call, Request: req}, in)
 	default:
 		err = &govarlink.ServerError{
 			Name:       "org.varlink.service.MethodNotFound",
@@ -115,6 +159,9 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 	}
 	if err != nil {
 		return marshalError(err)
+	}
+	if call.Replied() {
+		return nil
 	}
 	return call.CloseWithReply(out)
 }

--- a/example/internal/varlink/stringapi/org.example.string.go
+++ b/example/internal/varlink/stringapi/org.example.string.go
@@ -3,8 +3,10 @@
 package stringapi
 
 import (
+	"bufio"
 	"encoding/json"
 	govarlink "github.com/emersion/go-varlink"
+	"net"
 )
 
 type RandomIn struct{}
@@ -110,6 +112,21 @@ func (c Client) Random(in *RandomIn) (*RandomOut, error) {
 	err := c.Client.Do("org.example.string.Random", in, out)
 	return out, unmarshalError(err)
 }
+
+// RandomUpgrade calls org.example.string.Random, requesting the
+// connection to be upgraded.
+//
+// The service must take over the connection: if it replies without doing so,
+// the connection is closed. On success the caller owns the connection and must
+// close it, and must read from the returned bufio.Reader.
+func (c Client) RandomUpgrade(in *RandomIn) (*RandomOut, net.Conn, *bufio.Reader, error) {
+	if in == nil {
+		in = new(RandomIn)
+	}
+	out := new(RandomOut)
+	conn, br, err := c.Client.DoUpgrade("org.example.string.Random", in, out)
+	return out, conn, br, unmarshalError(err)
+}
 func (c Client) Repeat(in *RepeatIn) (*RepeatOut, error) {
 	if in == nil {
 		in = new(RepeatIn)
@@ -118,6 +135,21 @@ func (c Client) Repeat(in *RepeatIn) (*RepeatOut, error) {
 	err := c.Client.Do("org.example.string.Repeat", in, out)
 	return out, unmarshalError(err)
 }
+
+// RepeatUpgrade calls org.example.string.Repeat, requesting the
+// connection to be upgraded.
+//
+// The service must take over the connection: if it replies without doing so,
+// the connection is closed. On success the caller owns the connection and must
+// close it, and must read from the returned bufio.Reader.
+func (c Client) RepeatUpgrade(in *RepeatIn) (*RepeatOut, net.Conn, *bufio.Reader, error) {
+	if in == nil {
+		in = new(RepeatIn)
+	}
+	out := new(RepeatOut)
+	conn, br, err := c.Client.DoUpgrade("org.example.string.Repeat", in, out)
+	return out, conn, br, unmarshalError(err)
+}
 func (c Client) Reverse(in *ReverseIn) (*ReverseOut, error) {
 	if in == nil {
 		in = new(ReverseIn)
@@ -125,6 +157,21 @@ func (c Client) Reverse(in *ReverseIn) (*ReverseOut, error) {
 	out := new(ReverseOut)
 	err := c.Client.Do("org.example.string.Reverse", in, out)
 	return out, unmarshalError(err)
+}
+
+// ReverseUpgrade calls org.example.string.Reverse, requesting the
+// connection to be upgraded.
+//
+// The service must take over the connection: if it replies without doing so,
+// the connection is closed. On success the caller owns the connection and must
+// close it, and must read from the returned bufio.Reader.
+func (c Client) ReverseUpgrade(in *ReverseIn) (*ReverseOut, net.Conn, *bufio.Reader, error) {
+	if in == nil {
+		in = new(ReverseIn)
+	}
+	out := new(ReverseOut)
+	conn, br, err := c.Client.DoUpgrade("org.example.string.Reverse", in, out)
+	return out, conn, br, unmarshalError(err)
 }
 
 // Backend implements the org.example.string Varlink interface.

--- a/example/internal/varlink/stringapi/org.example.string.go
+++ b/example/internal/varlink/stringapi/org.example.string.go
@@ -12,6 +12,25 @@ type RandomOut struct {
 	Output string `json:"output"`
 }
 
+// RandomCall is an in-progress org.example.string.Random call.
+//
+// A reply may be sent with Reply or CloseWithReply instead of returning it
+// from the Backend method, for instance to hijack the connection afterwards.
+type RandomCall struct {
+	*govarlink.ServerCall
+	Request *govarlink.ServerRequest
+}
+
+// Reply sends a non-final reply.
+func (call *RandomCall) Reply(out *RandomOut) error {
+	return call.ServerCall.Reply(out)
+}
+
+// CloseWithReply sends a final reply and closes the call.
+func (call *RandomCall) CloseWithReply(out *RandomOut) error {
+	return call.ServerCall.CloseWithReply(out)
+}
+
 type RepeatIn struct {
 	Input string `json:"input"`
 }
@@ -19,11 +38,49 @@ type RepeatOut struct {
 	Output string `json:"output"`
 }
 
+// RepeatCall is an in-progress org.example.string.Repeat call.
+//
+// A reply may be sent with Reply or CloseWithReply instead of returning it
+// from the Backend method, for instance to hijack the connection afterwards.
+type RepeatCall struct {
+	*govarlink.ServerCall
+	Request *govarlink.ServerRequest
+}
+
+// Reply sends a non-final reply.
+func (call *RepeatCall) Reply(out *RepeatOut) error {
+	return call.ServerCall.Reply(out)
+}
+
+// CloseWithReply sends a final reply and closes the call.
+func (call *RepeatCall) CloseWithReply(out *RepeatOut) error {
+	return call.ServerCall.CloseWithReply(out)
+}
+
 type ReverseIn struct {
 	Input string `json:"input"`
 }
 type ReverseOut struct {
 	Output string `json:"output"`
+}
+
+// ReverseCall is an in-progress org.example.string.Reverse call.
+//
+// A reply may be sent with Reply or CloseWithReply instead of returning it
+// from the Backend method, for instance to hijack the connection afterwards.
+type ReverseCall struct {
+	*govarlink.ServerCall
+	Request *govarlink.ServerRequest
+}
+
+// Reply sends a non-final reply.
+func (call *ReverseCall) Reply(out *ReverseOut) error {
+	return call.ServerCall.Reply(out)
+}
+
+// CloseWithReply sends a final reply and closes the call.
+func (call *ReverseCall) CloseWithReply(out *ReverseOut) error {
+	return call.ServerCall.CloseWithReply(out)
 }
 
 type Client struct {
@@ -70,10 +127,16 @@ func (c Client) Reverse(in *ReverseIn) (*ReverseOut, error) {
 	return out, unmarshalError(err)
 }
 
+// Backend implements the org.example.string Varlink interface.
+//
+// A method may send the final reply itself via the provided call rather than
+// returning it, for instance to hijack the connection. It must then return a nil
+// output: the output is ignored, and returning an error after replying drops the
+// connection.
 type Backend interface {
-	Random(*RandomIn) (*RandomOut, error)
-	Repeat(*RepeatIn) (*RepeatOut, error)
-	Reverse(*ReverseIn) (*ReverseOut, error)
+	Random(*RandomCall, *RandomIn) (*RandomOut, error)
+	Repeat(*RepeatCall, *RepeatIn) (*RepeatOut, error)
+	Reverse(*ReverseCall, *ReverseIn) (*ReverseOut, error)
 }
 
 type Handler struct {
@@ -102,19 +165,19 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
 			return err
 		}
-		out, err = h.Backend.Random(in)
+		out, err = h.Backend.Random(&RandomCall{ServerCall: call, Request: req}, in)
 	case "org.example.string.Repeat":
 		in := new(RepeatIn)
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
 			return err
 		}
-		out, err = h.Backend.Repeat(in)
+		out, err = h.Backend.Repeat(&RepeatCall{ServerCall: call, Request: req}, in)
 	case "org.example.string.Reverse":
 		in := new(ReverseIn)
 		if err := json.Unmarshal(req.Parameters, in); err != nil {
 			return err
 		}
-		out, err = h.Backend.Reverse(in)
+		out, err = h.Backend.Reverse(&ReverseCall{ServerCall: call, Request: req}, in)
 	default:
 		err = &govarlink.ServerError{
 			Name:       "org.varlink.service.MethodNotFound",
@@ -123,6 +186,9 @@ func (h Handler) HandleVarlink(call *govarlink.ServerCall, req *govarlink.Server
 	}
 	if err != nil {
 		return marshalError(err)
+	}
+	if call.Replied() {
+		return nil
 	}
 	return call.CloseWithReply(out)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -12,11 +12,11 @@ import (
 
 type calcBackend struct{}
 
-func (calcBackend) Multiply(in *calcapi.MultiplyIn) (*calcapi.MultiplyOut, error) {
+func (calcBackend) Multiply(_ *calcapi.MultiplyCall, in *calcapi.MultiplyIn) (*calcapi.MultiplyOut, error) {
 	return &calcapi.MultiplyOut{Result: in.A * in.B}, nil
 }
 
-func (calcBackend) Divide(in *calcapi.DivideIn) (*calcapi.DivideOut, error) {
+func (calcBackend) Divide(_ *calcapi.DivideCall, in *calcapi.DivideIn) (*calcapi.DivideOut, error) {
 	if in.B == 0 {
 		return nil, &calcapi.DivisionByZeroError{}
 	}
@@ -25,11 +25,11 @@ func (calcBackend) Divide(in *calcapi.DivideIn) (*calcapi.DivideOut, error) {
 
 type stringBackend struct{}
 
-func (stringBackend) Repeat(in *stringapi.RepeatIn) (*stringapi.RepeatOut, error) {
+func (stringBackend) Repeat(_ *stringapi.RepeatCall, in *stringapi.RepeatIn) (*stringapi.RepeatOut, error) {
 	return &stringapi.RepeatOut{Output: in.Input}, nil
 }
 
-func (stringBackend) Reverse(in *stringapi.ReverseIn) (*stringapi.ReverseOut, error) {
+func (stringBackend) Reverse(_ *stringapi.ReverseCall, in *stringapi.ReverseIn) (*stringapi.ReverseOut, error) {
 	result := make([]rune, len(in.Input))
 	for i, char := range in.Input {
 		result[len(in.Input)-i-1] = char
@@ -37,7 +37,7 @@ func (stringBackend) Reverse(in *stringapi.ReverseIn) (*stringapi.ReverseOut, er
 	return &stringapi.ReverseOut{Output: string(result)}, nil
 }
 
-func (stringBackend) Random(_ *stringapi.RandomIn) (*stringapi.RandomOut, error) {
+func (stringBackend) Random(_ *stringapi.RandomCall, _ *stringapi.RandomIn) (*stringapi.RandomOut, error) {
 	// chosen by a fair dice roll, guaranteed to be random.
 	return &stringapi.RandomOut{Output: "4"}, nil
 }

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package varlink
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,6 +96,29 @@ func (call *ServerCall) CloseWithReply(parameters interface{}) error {
 	return call.reply(&serverReply{Parameters: parameters})
 }
 
+// Replied returns true if the final reply has been sent.
+func (call *ServerCall) Replied() bool {
+	return call.done
+}
+
+// Hijack takes over the connection, giving up Varlink message framing.
+//
+// This can only be used for a request with Upgrade set, after CloseWithReply.
+// The caller must read from the returned bufio.Reader, and is responsible for
+// closing the connection.
+func (call *ServerCall) Hijack() (net.Conn, *bufio.Reader, error) {
+	if !call.req.Upgrade {
+		return nil, nil, fmt.Errorf("varlink: ServerCall.Hijack called for a request without Upgrade set")
+	}
+	if call.req.Oneway {
+		return nil, nil, fmt.Errorf("varlink: ServerCall.Hijack called for a oneway request")
+	}
+	if !call.done {
+		return nil, nil, fmt.Errorf("varlink: ServerCall.Hijack called before ServerCall.CloseWithReply")
+	}
+	return call.conn.hijack()
+}
+
 // A Handler processes Varlink requests.
 type Handler interface {
 	HandleVarlink(call *ServerCall, req *ServerRequest) error
@@ -128,7 +152,11 @@ func (srv *Server) Serve(ln net.Listener) error {
 }
 
 func (srv *Server) serveConn(conn *conn) error {
-	defer conn.Close()
+	defer func() {
+		if !conn.hijacked.Load() {
+			conn.Close()
+		}
+	}()
 
 	for {
 		var req ServerRequest
@@ -138,15 +166,14 @@ func (srv *Server) serveConn(conn *conn) error {
 			return fmt.Errorf("reading request: %v", err)
 		}
 
-		if req.Upgrade {
-			return fmt.Errorf("varlink: connection upgrades not implemented")
-		}
-
 		call := &ServerCall{
 			conn: conn,
 			req:  &req,
 		}
 		err := srv.Handler.HandleVarlink(call, &req)
+		if conn.hijacked.Load() {
+			return err
+		}
 		var verr *ServerError
 		if errors.As(err, &verr) {
 			if req.Oneway {
@@ -164,6 +191,10 @@ func (srv *Server) serveConn(conn *conn) error {
 
 		if !req.Oneway && !call.done {
 			return fmt.Errorf("varlink: ServerCall.CloseWithReply not called")
+		}
+
+		if req.Upgrade && err == nil {
+			return fmt.Errorf("varlink: handler did not hijack an upgrade request for %q", req.Method)
 		}
 	}
 }

--- a/varlink.go
+++ b/varlink.go
@@ -6,13 +6,19 @@ package varlink
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"net"
+	"sync/atomic"
 )
+
+// ErrHijacked is returned when the connection has been hijacked.
+var ErrHijacked = errors.New("varlink: connection has been hijacked")
 
 type conn struct {
 	net.Conn
 
-	br *bufio.Reader
+	br       *bufio.Reader
+	hijacked atomic.Bool
 }
 
 func newConn(c net.Conn) *conn {
@@ -22,7 +28,17 @@ func newConn(c net.Conn) *conn {
 	}
 }
 
+func (c *conn) hijack() (net.Conn, *bufio.Reader, error) {
+	if !c.hijacked.CompareAndSwap(false, true) {
+		return nil, nil, ErrHijacked
+	}
+	return c.Conn, c.br, nil
+}
+
 func (c *conn) writeMessage(v interface{}) error {
+	if c.hijacked.Load() {
+		return ErrHijacked
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err


### PR DESCRIPTION
Implements the `upgrade` field from the Varlink protocol.

A client calls `Client.DoUpgrade`, or the generated `<Method>Upgrade`.
A handler takes the connection over with `ServerCall.Hijack` after
sending its final reply. Both hand back the `net.Conn` and its
`*bufio.Reader`, since bytes may already have been read past the last
message.

Backend methods now take a generated call type as their first argument,
which breaks existing implementations.
